### PR TITLE
Fixed Ascension Path Cyborg/Mechanical Conditions

### DIFF
--- a/rpg_traits/common/ascension_perks/00_ascension_perks.txt
+++ b/rpg_traits/common/ascension_perks/00_ascension_perks.txt
@@ -183,7 +183,6 @@ ap_engineered_evolution = {
 			has_authority = "auth_machine_intelligence"
 		}
 		is_mechanical_empire = no
-		is_cyborg_empire = no
 	}
 	
 	ai_weight = {
@@ -241,8 +240,7 @@ ap_evolutionary_mastery = {
 			has_ascension_perk = ap_evolutionary_mastery
 			has_authority = "auth_machine_intelligence"
 		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no		
+		is_mechanical_empire = no	
 	}
 	
 	ai_weight = {

--- a/rpg_traits/common/ascension_perks/00_ascension_perks.txt
+++ b/rpg_traits/common/ascension_perks/00_ascension_perks.txt
@@ -416,8 +416,6 @@ ap_mind_over_matter = {
 			has_ascension_perk = ap_mind_over_matter
 			has_authority = "auth_machine_intelligence"
 		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no
 	}
 	
 	ai_weight = {
@@ -468,9 +466,7 @@ ap_transcendence = {
 		NOT = {
 			has_ascension_perk = ap_transcendence
 			has_authority = "auth_machine_intelligence"
-		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no		
+		}		
 	}
 	
 	ai_weight = {

--- a/rpg_traits_heavy/common/ascension_perks/00_ascension_perks.txt
+++ b/rpg_traits_heavy/common/ascension_perks/00_ascension_perks.txt
@@ -183,7 +183,6 @@ ap_engineered_evolution = {
 			has_authority = "auth_machine_intelligence"
 		}
 		is_mechanical_empire = no
-		is_cyborg_empire = no
 	}
 	
 	ai_weight = {
@@ -241,8 +240,7 @@ ap_evolutionary_mastery = {
 			has_ascension_perk = ap_evolutionary_mastery
 			has_authority = "auth_machine_intelligence"
 		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no		
+		is_mechanical_empire = no		
 	}
 	
 	ai_weight = {
@@ -416,8 +414,6 @@ ap_mind_over_matter = {
 			has_ascension_perk = ap_mind_over_matter
 			has_authority = "auth_machine_intelligence"
 		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no
 	}
 	
 	ai_weight = {
@@ -468,9 +464,7 @@ ap_transcendence = {
 		NOT = {
 			has_ascension_perk = ap_transcendence
 			has_authority = "auth_machine_intelligence"
-		}
-		is_mechanical_empire = no
-		is_cyborg_empire = no		
+		}	
 	}
 	
 	ai_weight = {


### PR DESCRIPTION
These changes remove the absolute block on the psionic path for cyborgs and mechanical empires, so the psionic synth tech should work now. In addition, they remove the absolute block on cyborgs using the bio ascension path, but leave the block on empires using the Flesh is Weak ascension perk, as to allow empires with the Precursor trait to use bio ascension.